### PR TITLE
add (draft): taobench procedure draft

### DIFF
--- a/NOTEPAD.md
+++ b/NOTEPAD.md
@@ -1,0 +1,49 @@
+# Week of Apr 24 2023
+## Goodput
+Code for calculation of goodput and throughput below:
+```
+public double requestsPerSecondThroughput() {
+    return (double) measuredRequests / (double) nanoseconds * 1e9;
+}
+
+public double requestsPerSecondGoodput() {
+    return (double) success.getSampleCount() / (double) nanoseconds * 1e9;
+}
+```
+Looks like goodput is calculated purely from successful/completed transactions (does not include aborted/rejected trx)
+<br/>
+
+Issue that introduces goodput is [here](https://github.com/cmu-db/benchbase/pull/102)
+
+## Aborted vs Rejected Transactions (Server Retry)
+Rejected trx seems to be equivalent to retried trx where the trx did not execute.
+<br/>
+
+Whereas aborted trx has executed successfully but was aborted due to valid user control code (not sure in what cases this happends).
+<br/>
+
+See `TransactionStatus.java` code snippet below:
+```
+/**
+* The transaction executed successfully but then was aborted
+* due to the valid user control code.
+* This is not an error.
+*/
+USER_ABORTED,
+/**
+* The transaction did not execute due to internal
+* benchmark state. It should be retried
+*/
+RETRY,
+
+/**
+* The transaction did not execute due to internal
+* benchmark state. The Worker should retry but select
+* a new random transaction to execute.
+*/
+RETRY_DIFFERENT,
+```
+And rejected is the sum of both types of retries. See `DBWorkload.java`:
+```
+map.put("rejected", r.getRetry());
+```

--- a/config/mysql/sample_ycsb_config.xml
+++ b/config/mysql/sample_ycsb_config.xml
@@ -19,7 +19,18 @@
         <work>
             <time>60</time>
             <rate>10000</rate>
-            <weights>0,0,0,0,0,0,10,10</weights>
+            <weights>
+            0, <!-- Update -->
+            0, <!-- Scan -->
+            0, <!-- Read -->
+            0, <!-- ReadModifyWrite -->
+            0, <!-- Insert -->
+            0, <!-- Delete -->
+            0, <!-- ReadXWriteZ -->
+            0, <!-- ReadZWriteX -->
+            10, <!-- TaobenchReadXWriteZ -->
+            10 <!-- TaobenchReadZWriteX -->
+            </weights>
         </work>
     </works>
 
@@ -50,6 +61,12 @@
         </transactiontype>
         <transactiontype>
             <name>ReadZWriteXRecord</name>
+        </transactiontype>
+        <transactiontype>
+            <name>TaobenchReadXWriteZRecord</name>
+        </transactiontype>
+        <transactiontype>
+            <name>TaobenchReadZWriteXRecord</name>
         </transactiontype>
         <!-- END CUSTOM PROCEDURES -->
     </transactiontypes>

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/procedures/taobench procedures/TaobenchReadXWriteZRecord.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/procedures/taobench procedures/TaobenchReadXWriteZRecord.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.ycsb.procedures;
+
+import com.oltpbenchmark.api.Procedure;
+import com.oltpbenchmark.api.SQLStmt;
+import com.oltpbenchmark.benchmarks.ycsb.YCSBConstants;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static com.oltpbenchmark.benchmarks.ycsb.YCSBConstants.TABLE_NAME;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class TaobenchReadXWriteZRecord extends Procedure {
+    /**
+     * get random integer in range [min, max]
+     */
+    public int randInt(int min, int max) {
+        return ThreadLocalRandom.current().nextInt(min, max + 1);
+    }
+
+    public final SQLStmt selectXStmt = new SQLStmt(
+        "SELECT * FROM " + TABLE_NAME + " where YCSB_KEY=?" //  FOR UPDATE
+    );
+
+    public final SQLStmt updateZStmt = new SQLStmt(
+        "UPDATE " + TABLE_NAME + " SET FIELD1=?,FIELD2=?,FIELD3=?,FIELD4=?,FIELD5=?," +
+                "FIELD6=?,FIELD7=?,FIELD8=?,FIELD9=?,FIELD10=? WHERE YCSB_KEY=?"
+    );
+
+    public final SQLStmt fillerYStmt = new SQLStmt(
+        "SELECT * FROM " + TABLE_NAME + " where YCSB_KEY=?"
+    );
+
+    public final SQLStmt startTrxForStmt = new SQLStmt(
+        YCSBConstants.START_TRX_FOR_STMT
+    );
+
+    public final SQLStmt commitStmt = new SQLStmt(
+        YCSBConstants.COMMIT_TRX_STMT
+    );
+
+    //FIXME: The value in ysqb is a byteiterator
+    /**
+     * trx_typ: first argument for START FOR
+     * trx_args: remaining arguments for START FOR
+     * read_keys: keys to read from
+     * write_keys: keys to write to
+     */
+    public void run(Connection conn, int trx_typ, Integer[] trx_args, int[] read_keys, int[] write_keys, String[] fields, String[] results) throws SQLException {
+        // Prepare sets of read and write keys
+        float read_ratio = 0.5f;
+        List<Integer> read_hotkeys = new ArrayList<Integer>((int) Math.round(read_keys.length * read_ratio));
+        List<Integer> read_nonhotkeys = new ArrayList<Integer>(read_keys.length - (int) Math.round(read_keys.length * read_ratio));
+        for (int i = 0; i < read_keys.length; i++) {
+            if (i < read_keys.length / 2) {
+                read_hotkeys.add(read_keys[i]);
+            } else {
+                read_nonhotkeys.add(read_keys[i]);
+            }
+        }
+        java.util.Collections.shuffle(read_hotkeys);
+        java.util.Collections.shuffle(read_nonhotkeys);
+
+        List<Integer> write_nonhotkeys = new ArrayList<Integer>(write_keys.length);
+        for (int i = 0; i < write_keys.length; i++) {
+            write_nonhotkeys.add(write_keys[i]);
+        }
+        java.util.Collections.shuffle(write_nonhotkeys);
+
+        // START TRANSACTION
+        // Start trx for stmt
+        try (PreparedStatement stmt = this.getPreparedStatement(conn, startTrxForStmt)) {
+            stmt.setInt(1, trx_typ);
+            stmt.setInt(2, trx_args[0]);
+            stmt.setInt(3, trx_args[1]);
+            stmt.execute();
+        }
+
+        // Read from set of read hotkeys
+        for (int i = 0; i < read_hotkeys.size(); i++) {
+            try (PreparedStatement stmt = this.getPreparedStatement(conn, selectXStmt)) {
+                stmt.setInt(1, read_hotkeys.get(i));
+                try (ResultSet r = stmt.executeQuery()) {
+                    while (r.next()) {
+                        for (int j = 0; j < YCSBConstants.NUM_FIELDS; j++) {
+                            results[j] = r.getString(j + 1);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Read from set of read non-hotkeys
+        for (int i = 0; i < read_nonhotkeys.size(); i++) {
+            try (PreparedStatement stmt = this.getPreparedStatement(conn, fillerYStmt)) {
+                stmt.setInt(1, read_nonhotkeys.get(i));
+                try (ResultSet r = stmt.executeQuery()) {
+                    while (r.next()) {
+                        for (int j = 0; j < YCSBConstants.NUM_FIELDS; j++) {
+                            results[j] = r.getString(j + 1);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Write to set of write keys
+        for (int i = 0; i < write_nonhotkeys.size(); i++) {
+            try (PreparedStatement stmt = this.getPreparedStatement(conn, updateZStmt)) {
+                stmt.setInt(11, write_nonhotkeys.get(i));
+
+                for (int j = 0; j < fields.length; j++) {
+                    stmt.setString(j + 1, fields[j]);
+                }
+                stmt.executeUpdate();
+            }
+        }
+
+        // // Commit trx
+        // try (PreparedStatement stmt = this.getPreparedStatement(conn, commitStmt)) {
+        //     stmt.execute();
+        // }
+    }
+
+}

--- a/src/main/java/com/oltpbenchmark/benchmarks/ycsb/procedures/taobench procedures/TaobenchReadZWriteXRecord.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/ycsb/procedures/taobench procedures/TaobenchReadZWriteXRecord.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.oltpbenchmark.benchmarks.ycsb.procedures;
+
+import com.oltpbenchmark.api.Procedure;
+import com.oltpbenchmark.api.SQLStmt;
+import com.oltpbenchmark.benchmarks.ycsb.YCSBConstants;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static com.oltpbenchmark.benchmarks.ycsb.YCSBConstants.TABLE_NAME;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+
+public class TaobenchReadZWriteXRecord extends Procedure {
+    /**
+     * get random integer in range [min, max]
+     */
+    public int randInt(int min, int max) {
+        return ThreadLocalRandom.current().nextInt(min, max + 1);
+    }
+
+    public final SQLStmt selectXStmt = new SQLStmt(
+        "SELECT * FROM " + TABLE_NAME + " where YCSB_KEY=?" // FOR UPDATE
+    );
+
+    public final SQLStmt updateZStmt = new SQLStmt(
+        "UPDATE " + TABLE_NAME + " SET FIELD1=?,FIELD2=?,FIELD3=?,FIELD4=?,FIELD5=?," +
+                "FIELD6=?,FIELD7=?,FIELD8=?,FIELD9=?,FIELD10=? WHERE YCSB_KEY=?"
+    );
+
+    public final SQLStmt fillerYStmt = new SQLStmt(
+        "SELECT * FROM " + TABLE_NAME + " where YCSB_KEY=?"
+    );
+
+    public final SQLStmt startTrxForStmt = new SQLStmt(
+        YCSBConstants.START_TRX_FOR_STMT
+    );
+
+    public final SQLStmt commitStmt = new SQLStmt(
+        YCSBConstants.COMMIT_TRX_STMT
+    );
+
+    //FIXME: The value in ysqb is a byteiterator
+    /**
+     * X: single hotkey from group 1
+     * Z: single hotkey from group 2
+     * Y_start, Y_end: range of filler keys to use for filler stmts
+     */
+    public void run(Connection conn, int trx_typ, Integer[] trx_args, int X, int Z, int Z_start, int Z_end, String[] fields, String[] results) throws SQLException {
+        // TODO
+
+        // START TRANSACTION
+        // Start trx for stmt
+        try (PreparedStatement stmt = this.getPreparedStatement(conn, startTrxForStmt)) {
+            stmt.setInt(1, trx_typ);
+            stmt.setInt(2, trx_args[0]);
+            stmt.setInt(3, trx_args[1]);
+            stmt.execute();
+        }
+
+        // // Update that mofo
+        // try (PreparedStatement stmt = this.getPreparedStatement(conn, updateZStmt)) {
+        //     stmt.setInt(11, X);
+
+        //     for (int i = 0; i < fields.length; i++) {
+        //         stmt.setString(i + 1, fields[i]);
+        //     }
+        //     stmt.executeUpdate();
+        // }
+
+        // // Commit stmt
+        // try (PreparedStatement stmt = this.getPreparedStatement(conn, commitStmt)) {
+        //     stmt.execute();
+        // }
+    }
+
+}


### PR DESCRIPTION
DRAFT

[TaobenchReadXWriteZRecord.java](https://github.com/zenanana/benchbase/compare/central-sched...zenanana:benchbase:central-sched-taobench-workload?expand=1#diff-7a92163817435a0ec9067c156c97dc460932e4809c36ce217165f2f9c810b320) contains the new taobench procedure

[NOTEPAD.md](https://github.com/zenanana/benchbase/compare/central-sched...zenanana:benchbase:central-sched-taobench-workload?expand=1#diff-276d4aecf107a1c5db94f4e4c255ae68f3225986248e5f1079fd1422db6f9941) contains findings